### PR TITLE
fix: make onclose prop optional in InlineModal component

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "svelte-inline-modal",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "🪟 Simple Modal on the Fly",
   "type": "module",
   "main": "dist/index.js",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "repository": {
     "type": "git",
     "url": "git+https://github.com/jill64/svelte-inline-modal.git",
-    "image": "https://opengraph.githubassets.com/a732df20bbc1c50bcc28dfeeade792a3d1e3226558ee6690cf5d89ffb40a0de2/jill64/svelte-inline-modal"
+    "image": "https://opengraph.githubassets.com/99355f5c8cf9cb773e3666cff89eae3a01e4e6fff196e377fcae1a99b21580de/jill64/svelte-inline-modal"
   },
   "keywords": [
     "inline",

--- a/src/lib/InlineModal.svelte
+++ b/src/lib/InlineModal.svelte
@@ -6,7 +6,7 @@
     button,
     menu
   }: {
-    onclose: () => unknown
+    onclose?: () => unknown
     button: Snippet<[typeof open]>
     menu: Snippet<[typeof close]>
   } = $props()


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Package Updates**
  - Incremented package version to 2.0.1
  - Updated repository image URL

- **Component Improvements**
  - Made `onclose` prop optional in InlineModal component, providing more flexibility for users

<!-- end of auto-generated comment: release notes by coderabbit.ai -->